### PR TITLE
Today I learned - GitHub README under `.github` has precedence.

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,12 @@
+# Actions
+
+the `actions/` subfolder contains common
+[composite actions steps](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)
+that any workflow can use.
+
+### [setupconda](./setupconda/action.yaml)
+Steps to configure conda environment required to build the website.
+
+### [buildresources](./buildresources/action.yaml)
+Steps to build the hackweek landing webpage and JupyterBook.
+

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,53 +1,36 @@
-# GitHub Actions
-
-This folder contains the GitHub actions for the website.
-
-## Actions
-
-the `actions/` subfolder contains common
-[composite actions steps](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)
-that any workflow can use.
-
-#### [setupconda](./setupconda/action.yaml)
-Steps to configure conda environment required to build the website.
-
-#### [buildresources](./buildresources/action.yaml)
-Steps to build the hackweek landing webpage and JupyterBook.
-
-
-## Workflows
+# Workflows
 
 The `workflows/` subfolder contains continuous integration workflows.
 
-#### [binder-badge.yaml](../workflows/binder-badge.yaml)
+### [binder-badge.yaml](../workflows/binder-badge.yaml)
 Create [binder](https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html)
 badges with links to test tutorial notebooks
 
-#### [deploy.yaml](../workflows/deploy.yaml)
+### [deploy.yaml](../workflows/deploy.yaml)
 Render and publish the websites (JupyterBook and landing page) to GitHub Pages
 
-#### [manual.yaml](../workflows/manual.yaml)
+### [manual.yaml](../workflows/manual.yaml)
 Bypass usage of the cache to manually trigger a full rebuild of the JupyterBook
 and landing page
 
-#### [netlifypreview.yaml](../workflows/netlifypreview.yaml)
+### [netlifypreview.yaml](../workflows/netlifypreview.yaml)
 Creates public preview, via [netlify](https://jupyterbook.org/publish/netlify.html),
 of changes by building from a PR
 
-#### [qaqc.yaml](../workflows/qaqc.yaml)
+### [qaqc.yaml](../workflows/qaqc.yaml)
 Quality assessment and quality control. Standardizes formatting including spell
 check, hyperlink check, and clearing notebook outputs
 
-#### [repo2docker.yaml](../workflows/repo2docker.yaml)
+### [repo2docker.yaml](../workflows/repo2docker.yaml)
 [Build a Docker image](https://github.com/jupyterhub/repo2docker-action) for
 JupyterHub/BinderHub
 
-#### [test.yaml](../workflows/test.yaml)
+### [test.yaml](../workflows/test.yaml)
 Build the websites (JupyterBook and front page). Run on Pull Requests against
 every commit and via a 'cron' schedule to maintain caching
 [since otherwise the cache expires if untouched in 7 days](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)
 
-#### [update_fr_template.yaml](../workflows/update_fr_template.yaml)
+### [update_fr_template.yaml](../workflows/update_fr_template.yaml)
 Update the current repo from the original template (`uwhackweek/jupyterbook-template`).
 Run manually to collect any updates made to template files listed in
 `.templaterc.json`, commit them to a new branch, and submit a PR the
@@ -60,3 +43,4 @@ website repository should allow for changes via pull requests from forks. By
 default workflows running off forked repositories do not have access to
 secrets, but [following security best practices](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) you can require adding a label to a pull request in order to run a workflow that requires secrets. For an example, see the [netlifypreview.yaml](./actions/workflows/netlifypreview.yaml)
 workflow.
+


### PR DESCRIPTION
Was confused why the README under the root folder was not shown on [the repositories homepage](https://github.com/geo-smart/hackweek-website-2023). Interestingly, GitHub first looks under the `.github` folder for a README to render and it has precedence over the one under the root.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#about-readmes

Personally, I find that an interesting priority treatment.