### PR TITLE
Splashpage - Expand HW event description per default

### DIFF
--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -153,17 +153,17 @@
             <div class="accordion" id="expandDescription">
               <div class="accordion-item">
                 <h2 class="accordion-header" id="headingOne">
-                  <button class="accordion-button collapsed"
+                  <button class="accordion-button"
                           type="button"
                           data-bs-toggle="collapse"
                           data-bs-target="#collapseList"
-                          aria-expanded="false"
+                          aria-expanded="true"
                           aria-controls="collapseList">
                       {{ cookiecutter.about.expanded_description.header }}
                   </button>
                 </h2>
                 <div id="collapseList"
-                     class="accordion-collapse collapse"
+                     class="accordion-collapse collapse show"
                      aria-labelledby="headingOne"
                      data-bs-parent="#headingOne">
                   <div class="accordion-body">


### PR DESCRIPTION
Have the list of activities expanded upon visit and make it still collapsable