### PR TITLE
Add link to project form on website

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -21,7 +21,7 @@ parse:
     contact_email: "geohack@uw.edu"
     dataset: "GeoSmart"
     anon_reporting_url: "https://INSERT_FORM_LINK"
-    project_spreadsheet_url: "https://INSERT_GOOGLE_SHEET"
+    project_spreadsheet_url: "https://docs.google.com/forms/d/e/1FAIpQLSf1oHsbNSwxFVu54KujUi6zpwt_RNxS9Bvod18f-CFyVKFQCA/viewform"
   myst_enable_extensions:
     # Defaults
     - dollarmath

--- a/book/intro.md
+++ b/book/intro.md
@@ -5,7 +5,7 @@
 
 📖 On this JupyterBook website you'll find [tutorials](tutorials/index). All tutorials are Jupyter Notebooks, designed to be run interactively, but also rendered on this website for convenience.
 
-👩‍💻 During a Hackweek teams work collaboratively on different projects. Read more about the projects and results on our [projects page](projects/list_of_projects)
+👩‍💻 During a Hackweek teams work collaboratively on different projects. Read more about the projects and results on our [projects page](projects/list_of_projects).
 
 💡 Learn more about hackweeks hosted by the [University of Washington eScience Institute](https://uwhackweek.github.io/hackweeks-as-a-service/intro.html), or check out our publication describing the hackweek educational model {cite:p}`Huppenkothen2018`.
 
@@ -13,5 +13,5 @@
 :class: seealso
 * JupyterHub: {{ jupyterhub_url }}
 * GitHub organization: {{ github_org_url}}
-* Projects Spreadsheet: {{ project_spreadsheet_url }}
+* Projects Signup Form: {{ project_spreadsheet_url }}
 ```


### PR DESCRIPTION
Instead of linking to a spreadsheet like we've done in the past, I'm linking to the project sign up form that @markweldensmith created.